### PR TITLE
Fix error msg display on enter key press, add CSS transitions and jQuery fadeIn/fadeOut

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -52,9 +52,8 @@ hr {
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-  transition-property: all;
+  transition-property: background-color;
   transition-duration: 1s;
-  transition-timing-function: ease-in-out;
 }
 
 .box a {

--- a/css/main.css
+++ b/css/main.css
@@ -17,12 +17,28 @@ hr {
   font-weight: 800;
   font-size: 16px;
   width: 92.5%;
+  transition-property: background-color, color, border;
+  transition-duration: 1s, 1s, 1s;
+  transition-timing-function: ease-in-out;
 }
 
 #clear-button:hover,
 #create-button:hover {
   background-color: #ffd773;
   cursor: pointer;
+  border: 2px solid #ffd773;
+  transition-property: background-color, border;
+  transition-duration: .25s, .25s;
+  transition-timing-function: ease-in-out;
+}
+
+#clear-button:active,
+#create-button:active {
+  background-color: #ff9c07;
+  border: #ff9c07;
+  transition-property: none;
+  /*transition-duration: .25s;*/
+  /*transition-timing-function: ease-in-out;*/
 }
 
 .box {
@@ -36,6 +52,9 @@ hr {
   display: flex;
   flex-direction: column;
   justify-content: space-around;
+  transition-property: all;
+  transition-duration: 1s;
+  transition-timing-function: ease-in-out;
 }
 
 .box a {
@@ -55,6 +74,7 @@ hr {
 
 button:focus {
   outline:0;
+  filter: opacity(90%);
 }
 
 .delete-button {
@@ -68,6 +88,7 @@ div button {
   position: relative;
   border: none;
   background-color: #fff;
+  text-decoration: none;
 }
 
 .form {
@@ -104,10 +125,18 @@ div button {
 .read {
   background-color: #f2f4f4;
 }
+
 .read .read-button {
   color: #f05128;
   border: none;
   background-color: #f2f4f4;
+}
+
+.read-button, .delete-button {
+  text-decoration: none;
+  border-bottom: none;
+  transition-duration: 1s;
+  transition-timing-function: ease-in-out;
 }
 
 .read .delete-button {
@@ -135,6 +164,10 @@ div button {
   display: inline-block;
 }
 
+.hov-line {
+  /*transition-property: all;*/
+  /*transition-duration: 1s*/
+}
 
 #create-button:disabled, #clear-button:disabled,
 #create-button[disabled]:active, #clear-button[disabled]:active,
@@ -169,9 +202,19 @@ input:focus{
 
 .error-msg {
   opacity: 0;
-  color: #ff5185;
-  text-shadow: black -1px 1px 1px;
+  width: 90%;
+  color: white;
+  text-shadow: black -1px 1px .5px;
   text-align: center;
+  padding: 8px;
+  background-color: #ff1744;
+  margin: 0 auto;
+  display: inline-block;
+  border-radius: 5px;
+  border: 1px solid #ef5350;
+  transition-property: all;
+  transition-duration: .5s;
+  transition-timing-function: ease-in-out;
 }
 
 .hov-line:hover {

--- a/scripts/linked-list.js
+++ b/scripts/linked-list.js
@@ -16,14 +16,19 @@ var errorMsg = $('.error-msg');
 clearButton.attr('disabled', true);
 createButton.attr('disabled', true);
 
+titleForm.focus();
+
 function displayError() {
-  errorMsg.css('opacity', '1');
+  errorMsg.css('opacity', '.85');
   errorMsg.css('transition-duration', '.5s');
 };
 
-inputFields.on('blur keyup', function () {
+function hideError() {
   errorMsg.css('opacity', '0');
   errorMsg.css('transition-duration', '.5s');
+};
+
+inputFields.on('blur keypress', function () {
 
   var titleString = $('#title-form').val();
   var urlString = $('#url-form').val();
@@ -33,6 +38,7 @@ inputFields.on('blur keyup', function () {
   if (urlEmpty || titleEmpty) {
     createButton.attr('disabled', true);
   } else if (!urlEmpty && !titleEmpty) {
+    hideError();
     createButton.attr('disabled', false);
   }
 });
@@ -41,6 +47,7 @@ function stringIsEmpty(string) {
   return string.length === 0 || (/^(\s)*$/g).test(string);
 }
 
+// click the create-button when user hits enter key
 inputFields.keypress(function(event){
   if (event.which == 13) {
     $('#create-button').click();
@@ -68,6 +75,8 @@ $('#create-button').on('click', function() {
     updateCounters();
     addCardToList(titleText, validURL);
     createButton.attr('disabled', true);
+    hideError();
+    titleForm.focus();
   } else {
     displayError();
   }

--- a/scripts/linked-list.js
+++ b/scripts/linked-list.js
@@ -96,7 +96,7 @@ function addCardToList(titleText, validURL) {
                       <p><span class="hov-line">Delete</span></p>\
                     </button>\
                   </div>\
-               </article>').hide().fadeIn('fast');
+               </article>').hide().fadeIn('normal');
   list.append(newCard);
 };
 
@@ -114,15 +114,16 @@ $('.list').on('click', '.read-button', function() {
 });
 
 $('.list').on('click', '.delete-button', function() {
-  //$(this).parents('article').remove();
-  $(this).parents('.box').fadeOut('fast', function () {
+  $(this).parents('.box').fadeOut('normal', function () {
     $(this).remove();
   });
   updateCounters();
 });
 
 $('.form').on('click', '#clear-button', function() {
-  $('.list').children('.read').remove()
+  $('.list').children('.read').fadeOut('normal', function () {
+    $(this).remove();
+  });
   updateCounters();
 });
 

--- a/scripts/linked-list.js
+++ b/scripts/linked-list.js
@@ -83,7 +83,7 @@ $('#create-button').on('click', function() {
 });
 
 function addCardToList(titleText, validURL) {
-  list.append('<article class="box" id="bookmark-' + count + '">\
+  var newCard = $('<article class="box" id="bookmark-' + count + '">\
                  <h1 class="bookmark-title"> ' + titleText + '</h1><hr>\
                    <a class=".bookmark-url" href="' + validURL + '">\
                      <p><span class="hov-line">' + validURL + '</span></p>\
@@ -96,7 +96,8 @@ function addCardToList(titleText, validURL) {
                       <p><span class="hov-line">Delete</span></p>\
                     </button>\
                   </div>\
-               </article>');
+               </article>').hide().fadeIn('fast');
+  list.append(newCard);
 };
 
 function urlIsValid(titleText, urlText) {
@@ -113,7 +114,10 @@ $('.list').on('click', '.read-button', function() {
 });
 
 $('.list').on('click', '.delete-button', function() {
-  $(this).parents('article').remove();
+  //$(this).parents('article').remove();
+  $(this).parents('.box').fadeOut('fast', function () {
+    $(this).remove();
+  });
   updateCounters();
 });
 


### PR DESCRIPTION
Fixed the logic of displaying the error message after a user attempts to submit an invalid URL using the enter key to submit, so now it stays displayed until the user starts retyping the URL instead of immediately disappearing. I also changed the styling of the error message display and DRY'd up some of the error message handling in the JS. 

I also added some CSS transition animations when marking cards "read" and when changing the status of the create and clear-all buttons. I also added a jQuery `fadeIn` effect when adding cards to the list and a `fadeOut` effect when removing both individual cards and clearing all read. The trick is to make sure the CSS animations/transitions in `main.css` don't conflict with whatever CSS the jQuery is adding behind the scenes. I had trouble getting the `hov-line`s to animate properly on `:hover` so I ended up leaving those as is for now.

The only obvious bug right now is that the "read" text on each card doesn't turn red after marking a card. I'll open an issue for this one. 
